### PR TITLE
Add project overview page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-test
+# Testgelände
+
+Dies ist ein kleines Sammel-Repository für verschiedene Beispiel-Webseiten. Die neue Datei `website/overview.html` bietet eine Übersicht aller Projekte mit Live-Vorschau in Form von iframes. Beim Überfahren der Vorschau mit der Maus vergrößern sich die Ausschnitte und zeigen zusätzliche Informationen an.
+
+Siehe auch `docs/overview_plan.md` für Details zur Planung.

--- a/docs/overview_plan.md
+++ b/docs/overview_plan.md
@@ -1,0 +1,17 @@
+# Übersicht-Seite für Projekte
+
+Dieses Dokument enthält die Planung für eine moderne Übersicht-Seite im Dark-Mode.
+
+## Ziele
+* Darstellung mehrerer Projekte mit Live-Vorschau
+* Verwendung von Bootstrap (CDN) im Dark-Mode
+* Beim Hover vergrößert sich die Vorschau und blendet Details ein
+
+## Technisches Konzept
+1. **Struktur:** Verwendung eines Grid-Layouts mit Bootstrap (`row` und `col`).
+2. **Vorschau:** Jede Vorschau besteht aus einem `iframe` in einer Wrapper-Div.
+3. **Hover-Effekt:** Mittels CSS-Transformation (`scale`) und einer Overlay-Div werden bei Hover Details angezeigt.
+4. **Responsive:** Bootstrap sorgt für Anpassung an verschiedene Bildschirmgrößen.
+5. **Assets:** Erweiterung der vorhandenen `style.css` sowie `app.js` für eventuelle JS-Effekte.
+
+Die Umsetzung erfolgt in der Datei `website/overview.html`.

--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -2,8 +2,38 @@ body {
     font-family: Arial, sans-serif;
     margin: 0;
     padding: 0;
+    background-color: #121212;
+    color: #eee;
 }
+
 header, footer {
-    background-color: #f0f0f0;
+    background-color: #1f1f1f;
     padding: 10px;
+}
+
+.project-item {
+    height: 200px;
+    transition: transform 0.3s;
+}
+
+.project-item iframe {
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+}
+
+.project-overlay {
+    background-color: rgba(0, 0, 0, 0.7);
+    color: #fff;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+.project-item:hover {
+    transform: scale(1.05);
+    z-index: 2;
+}
+
+.project-item:hover .project-overlay {
+    opacity: 1;
 }

--- a/website/assets/js/app.js
+++ b/website/assets/js/app.js
@@ -1,3 +1,3 @@
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', () => {
     console.log('JavaScript is running');
 });

--- a/website/overview.html
+++ b/website/overview.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="de" data-bs-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Projektübersicht</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-gNbFdDSp1pAPT9d21Lk2f+KMX11wVOLiGB+SBio/3c9T1kAQeu57Pmuxe5btEf8G" crossorigin="anonymous">
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+  <div class="container py-4">
+    <h1 class="mb-4 text-center">Meine Projekte</h1>
+    <div class="row g-4" id="project-grid">
+      <!-- Projekt 1 -->
+      <div class="col-sm-6 col-lg-4">
+        <div class="project-item position-relative overflow-hidden rounded">
+          <iframe src="index.html" class="w-100 border-0"></iframe>
+          <div class="project-overlay position-absolute top-0 start-0 w-100 h-100 d-flex flex-column justify-content-center align-items-center text-center">
+            <h4>Sample HTML</h4>
+            <p class="small">Einfache statische Seite</p>
+          </div>
+        </div>
+      </div>
+      <!-- Projekt 2 -->
+      <div class="col-sm-6 col-lg-4">
+        <div class="project-item position-relative overflow-hidden rounded">
+          <iframe src="php/index.php" class="w-100 border-0"></iframe>
+          <div class="project-overlay position-absolute top-0 start-0 w-100 h-100 d-flex flex-column justify-content-center align-items-center text-center">
+            <h4>PHP Beispiel</h4>
+            <p class="small">Seite mit PHP Includes</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-N0puPjwW4AXDuaeqJXDMaaJaqy1q5br/1Jyz9R9G7xGRdASQa4O9rz+U91GLa7bs" crossorigin="anonymous"></script>
+  <script src="assets/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- plan design in `docs/overview_plan.md`
- update repo `README.md`
- add a Bootstrap-based overview page with iframe previews
- style the page with dark theme and hover effects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c8d1e256483299b76e430f77f37b9