### PR TITLE
Add JavaScript pocket calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Testgelände
 
-Dies ist ein kleines Sammel-Repository für verschiedene Beispiel-Webseiten. Die neue Datei `website/overview.html` bietet eine Übersicht aller Projekte mit Live-Vorschau in Form von iframes. Beim Überfahren der Vorschau mit der Maus vergrößern sich die Ausschnitte und zeigen zusätzliche Informationen an.
+Dies ist ein kleines Sammel-Repository für verschiedene Beispiel-Webseiten. Die neue Datei `website/overview.html` bietet eine Übersicht aller Projekte mit Live-Vorschau in Form von iframes. Beim Überfahren der Vorschau mit der Maus vergrößern sich die Ausschnitte und zeigen zusätzliche Informationen an. Neu hinzugekommen ist ein einfacher JavaScript-Taschenrechner (`website/calculator.html`), der über die Übersichtsseite erreichbar ist.
 
 Siehe auch `docs/overview_plan.md` für Details zur Planung.

--- a/docs/overview_plan.md
+++ b/docs/overview_plan.md
@@ -14,4 +14,4 @@ Dieses Dokument enthält die Planung für eine moderne Übersicht-Seite im Dark-
 4. **Responsive:** Bootstrap sorgt für Anpassung an verschiedene Bildschirmgrößen.
 5. **Assets:** Erweiterung der vorhandenen `style.css` sowie `app.js` für eventuelle JS-Effekte.
 
-Die Umsetzung erfolgt in der Datei `website/overview.html`.
+Die Umsetzung erfolgt in der Datei `website/overview.html`. Neben einfachen Beispielseiten wird dort auch ein JavaScript-Taschenrechner eingebunden.

--- a/website/assets/css/calculator.css
+++ b/website/assets/css/calculator.css
@@ -1,0 +1,48 @@
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    background-color: #121212;
+    color: #fff;
+    font-family: Arial, sans-serif;
+}
+
+.calculator {
+    border: 1px solid #333;
+    padding: 20px;
+    border-radius: 5px;
+    background-color: #1f1f1f;
+}
+
+.display {
+    width: 100%;
+    height: 40px;
+    margin-bottom: 10px;
+    text-align: right;
+    padding: 5px;
+    font-size: 1.2rem;
+    background-color: #000;
+    color: #0f0;
+    border: none;
+}
+
+.buttons {
+    display: grid;
+    grid-template-columns: repeat(4, 60px);
+    grid-gap: 5px;
+}
+
+button {
+    height: 40px;
+    font-size: 1rem;
+    background-color: #333;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+}
+
+button.equal {
+    grid-column: span 4;
+    background-color: #007bff;
+}

--- a/website/assets/js/calculator.js
+++ b/website/assets/js/calculator.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const display = document.getElementById('display');
+    document.querySelectorAll('.buttons button').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const value = btn.dataset.value;
+            const action = btn.dataset.action;
+            if (action === 'clear') {
+                display.value = '';
+                return;
+            }
+            if (action === 'equals') {
+                try {
+                    display.value = Function('return ' + display.value)();
+                } catch (e) {
+                    display.value = 'Fehler';
+                }
+                return;
+            }
+            display.value += value;
+        });
+    });
+});

--- a/website/calculator.html
+++ b/website/calculator.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Taschenrechner</title>
+  <link rel="stylesheet" href="assets/css/calculator.css">
+</head>
+<body>
+  <div class="calculator">
+    <input type="text" id="display" class="display" disabled>
+    <div class="buttons">
+      <button data-value="7">7</button>
+      <button data-value="8">8</button>
+      <button data-value="9">9</button>
+      <button data-value="/">&divide;</button>
+
+      <button data-value="4">4</button>
+      <button data-value="5">5</button>
+      <button data-value="6">6</button>
+      <button data-value="*">&times;</button>
+
+      <button data-value="1">1</button>
+      <button data-value="2">2</button>
+      <button data-value="3">3</button>
+      <button data-value="-">-</button>
+
+      <button data-value="0">0</button>
+      <button data-value=".">.</button>
+      <button data-action="clear">C</button>
+      <button data-value="+">+</button>
+
+      <button class="equal" data-action="equals">=</button>
+    </div>
+  </div>
+<script src="assets/js/calculator.js"></script>
+</body>
+</html>

--- a/website/overview.html
+++ b/website/overview.html
@@ -31,6 +31,16 @@
           </div>
         </div>
       </div>
+      <!-- Projekt 3 -->
+      <div class="col-sm-6 col-lg-4">
+        <div class="project-item position-relative overflow-hidden rounded">
+          <iframe src="calculator.html" class="w-100 border-0"></iframe>
+          <div class="project-overlay position-absolute top-0 start-0 w-100 h-100 d-flex flex-column justify-content-center align-items-center text-center">
+            <h4>Taschenrechner</h4>
+            <p class="small">Einfacher JavaScript-Rechner</p>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-N0puPjwW4AXDuaeqJXDMaaJaqy1q5br/1Jyz9R9G7xGRdASQa4O9rz+U91GLa7bs" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- add a simple JS calculator web page
- add CSS and JS assets for calculator
- link calculator from overview page
- document the new project in README and docs

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c91d3e258832994b96f01ea227621