### PR TITLE
Add Minesweeper skeleton with Bootstrap assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Dies ist ein kleines Test-Repository. Neben der bestehenden Beispiel-Webseite be
 Im Ordner `calculator` liegt eine kleine HTML/CSS/JavaScript-Anwendung, die einen simplen, aber dynamischen Taschenrechner bereitstellt. Die `index.html` kann direkt im Browser geöffnet werden.
 
 Der Taschenrechner ist zusätzlich über die Beispiel-Webseite erreichbar. Dort befindet sich nun ein Link, der auf die Anwendung verweist.
+
+## Minesweeper
+
+Im Ordner `minesweeper` liegt ein einfaches Grundgerüst für das bekannte
+Minesweeper-Spiel. Das Layout nutzt Bootstrap und kleine Emoji-Symbole für Mine
+und Fahne. Die Logik ist nur angedeutet, kann aber leicht erweitert werden.
+Auch auf der Beispiel-Webseite gibt es einen Link zu dieser Anwendung.

--- a/minesweeper/assets/flag.svg
+++ b/minesweeper/assets/flag.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M6 2v20" stroke="black" stroke-width="2"/>
+  <path d="M6 2h12l-4 6 4 6H6" fill="red" stroke="red" stroke-width="2"/>
+</svg>

--- a/minesweeper/assets/mine.svg
+++ b/minesweeper/assets/mine.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="5" fill="black"/>
+  <line x1="12" y1="1" x2="12" y2="5" stroke="black" stroke-width="2"/>
+  <line x1="12" y1="19" x2="12" y2="23" stroke="black" stroke-width="2"/>
+  <line x1="1" y1="12" x2="5" y2="12" stroke="black" stroke-width="2"/>
+  <line x1="19" y1="12" x2="23" y2="12" stroke="black" stroke-width="2"/>
+</svg>

--- a/minesweeper/index.html
+++ b/minesweeper/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Minesweeper</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="container py-4">
+    <h1 class="mb-4">Minesweeper</h1>
+    <div id="board" class="board"></div>
+    <template id="tile-template">
+        <button class="tile btn btn-light"></button>
+    </template>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/minesweeper/script.js
+++ b/minesweeper/script.js
@@ -1,0 +1,16 @@
+// Simple placeholder setup for a 10x10 board
+// This does not include full game logic yet
+
+document.addEventListener('DOMContentLoaded', () => {
+    const board = document.getElementById('board');
+    const template = document.getElementById('tile-template');
+
+    for (let i = 0; i < 100; i++) {
+        const tile = template.content.firstElementChild.cloneNode(true);
+        board.appendChild(tile);
+    }
+
+    // Demo icons
+    board.children[5].classList.add('mine');
+    board.children[10].classList.add('flag');
+});

--- a/minesweeper/style.css
+++ b/minesweeper/style.css
@@ -1,0 +1,30 @@
+body {
+    background-color: #f4f4f4;
+    font-family: Arial, sans-serif;
+}
+
+.board {
+    display: grid;
+    grid-template-columns: repeat(10, 32px);
+    grid-auto-rows: 32px;
+    gap: 2px;
+}
+
+.tile {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 18px;
+    line-height: 1;
+}
+
+.tile.flag {
+    background: url('assets/flag.svg') center/20px 20px no-repeat;
+}
+
+.tile.mine {
+    background: url('assets/mine.svg') center/20px 20px no-repeat;
+}

--- a/website/index.html
+++ b/website/index.html
@@ -9,6 +9,7 @@
   <h1>Hello from HTML page</h1>
   <nav>
     <a href="../calculator/index.html">Taschenrechner</a>
+    <a href="../minesweeper/index.html">Minesweeper</a>
   </nav>
   <script src="assets/js/app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add new `minesweeper` folder with Bootstrap-based starter
- include SVG icons and simple board styling
- demonstrate icons in a small script
- link minesweeper from the website
- document Minesweeper app in README

## Testing
- `node --version`
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca184c7908329b5530e28329e6bde